### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -14,7 +14,7 @@
     ],
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
-  "nxCloudId": "673ad6f2ead4370e80a38ad2",
+  "nxCloudId": "6743de001ef91af262ecd2b1",
   "plugins": [
     {
       "plugin": "@nx/webpack/plugin",
@@ -24,17 +24,10 @@
         "previewTargetName": "preview"
       }
     },
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint"
-      }
-    },
+    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } },
     {
       "plugin": "@nx/jest/plugin",
-      "options": {
-        "targetName": "test"
-      },
+      "options": { "targetName": "test" },
       "exclude": [
         "apps/nimo-coding-test-e2e/**/*",
         "apps/auth-api-e2e/**/*",


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 
    
This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/67433d6d695a61db2104d7bf/workspaces/6743de001ef91af262ecd2b1

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.